### PR TITLE
Adding an option to save color images with a higher resolution

### DIFF
--- a/PDFUtils.h
+++ b/PDFUtils.h
@@ -69,6 +69,9 @@ std::unique_ptr<PIX> getFullRenderPix(PDFDoc *doc, int page, double dpi);
 // Gets a PIX of the given page rendered wthout text at the given dpi.
 std::unique_ptr<PIX> getGraphicOnlyPix(PDFDoc *doc, int page, double dpi);
 
+// Gets a PIX of the given page rendered at the given dpi with splashModeRGB8 color mode.
+std::unique_ptr<PIX> getFullColorRenderPix(PDFDoc *doc, int page, double dpi);
+
 // Gets the TextPage* objects of a document at a given dpi.
 std::vector<TextPage *> getTextPages(PDFDoc *doc, double dpi);
 
@@ -83,6 +86,9 @@ void writeText(TextPage *page, BOX *bb, const char *name, std::ostream &output);
 
 void saveFiguresImage(std::vector<Figure> &figures, PIX *original,
                       std::string prefix);
+
+void saveFiguresFullColorImage(std::vector<Figure> &figures, PIX *original,
+                      std::string prefix, int multidpi);
 
 void writeFigureJSON(Figure &figures, int height, int width, double dpi,
                      std::vector<TextPage *> &text, std::ostream &output);

--- a/pdffigures.cpp
+++ b/pdffigures.cpp
@@ -228,11 +228,6 @@ int main(int argc, char **argv) {
       graphics1d = std::unique_ptr<PIX>(pixCreateTemplate(fullRender1d.get()));
     }
 
-    std::unique_ptr<PIX> fullColorRender;
-    if(colorImagePrefix.length() != 0){
-      fullColorRender = getFullColorRenderPix(doc.get(), onPage + 1, resolution * resMultiply);
-    }
-
     // Remove graphical elements that did not show up in the original due
     // to PDF shenanigans.
     pixAnd(graphics1d.get(), graphics1d.get(), fullRender1d.get());
@@ -270,7 +265,9 @@ int main(int argc, char **argv) {
     if (imagePrefix.length() != 0) {
       saveFiguresImage(figures, fullRender.get(), imagePrefix);
     }
+    std::unique_ptr<PIX> fullColorRender;
     if (colorImagePrefix.length() != 0) {
+      fullColorRender = getFullColorRenderPix(doc.get(), onPage + 1, resolution * resMultiply);
       saveFiguresFullColorImage(figures, fullColorRender.get(), colorImagePrefix, resMultiply);
     }
     if (showFinal or finalPrefix.length() != 0) {


### PR DESCRIPTION
I just added an option (-c, --save-color-images) for saving figures as color images with a higher resolution. Since the previous dpi option in your code is tuned for the best performance, I didn't change any of such settings. I remained all your codes but added a few variables/functions to save high resolution images without diminishing the performance.